### PR TITLE
Update CompleteManyTasksOnList.dialog

### DIFF
--- a/dialog/en-us/CompleteManyTasksOnList.dialog
+++ b/dialog/en-us/CompleteManyTasksOnList.dialog
@@ -1,1 +1,1 @@
-{{nofTask}} tasks named {{taskName}} on list {{listName}} was marked complete
+{{nofTask}} tasks named {{taskName}} on list {{listName}} were marked complete


### PR DESCRIPTION
This minor error was kindly identified by LeBelle as they were completing translations on Mycroft Translate; 

```
Username: LeBelle Current URL: https://translate.mycroft.ai/de/mycroft-skills/translate/carstena-the-cows-lists-de.po IP address: [identifying information removed for privacy]

Unit: https://translate.mycroft.ai/de/mycroft-skills/translate/carstena-the-cows-lists-de.po#unit=78266

Source: {{nofTask}} tasks named {{taskName}} on list {{listName}} was marked complete

Current translation: {{nofTask}} Aufgaben namens {{taskName}} auf der Liste {{listName}} wurden als abgeschlossen markiert

Your question or comment:

Shouldn&#39;t it be &#39;were marked complete&#39;?
```

I am raising a PR on LeBelle's behalf. 

Kind regards, 
Kathy